### PR TITLE
Add custom spec/global icon support and global anchor tabs in CDM options

### DIFF
--- a/Custom-Widgets/AceGUIContainer-SCMHorizontalScrollFrame.lua
+++ b/Custom-Widgets/AceGUIContainer-SCMHorizontalScrollFrame.lua
@@ -3,7 +3,7 @@ ScrollFrame Container
 Plain container that scrolls its content and doesn't grow in height.
 -------------------------------------------------------------------------------]]
 
-local Type, Version = "SCMHorizontalScrollFrame", 2
+local Type, Version = "SCMHorizontalScrollFrame", 3
 local AceGUI = LibStub and LibStub("AceGUI-3.0", true)
 if not AceGUI or (AceGUI:GetWidgetVersion(Type) or 0) >= Version then
 	return
@@ -246,6 +246,28 @@ local methods = {
 
 	["AddSpellByCooldownID"] = function(self, cooldownID)
 		--self.dataProvider:Insert()
+	end,
+
+
+	["AddCustomIcon"] = function(self, iconData)
+		local highestIndex = 0
+		for _, data in self.dataProvider:Enumerate() do
+			if data.dataIndex > highestIndex and data.dataIndex < 100 then
+				highestIndex = data.dataIndex
+			end
+		end
+		local dataIndex = highestIndex + 1
+		self.dataProvider:Insert({
+			dataIndex = dataIndex,
+			texture = iconData.texture,
+			spellID = iconData.spellID,
+			itemID = iconData.itemID,
+			isKnown = true,
+			isCustom = true,
+			iconType = iconData.iconType,
+			id = iconData.id,
+		})
+		return dataIndex
 	end,
 
 	["AddAddButton"] = function(self)

--- a/Database/defaults.lua
+++ b/Database/defaults.lua
@@ -4,6 +4,18 @@ SCM.Defaults = {}
 
 SCM.DefaultDB = {
     global = {
+		globalAnchorConfig = {
+			[1] = {
+				anchor = { "CENTER", "UIParent", "CENTER", 0, -360 },
+				rowConfig = {
+					[1] = {
+						size = 40,
+						limit = 8,
+					},
+				},
+			},
+		},
+		globalCustomIcons = {},
 		options = {
 			showAnchorHighlight = true,
 			debug = false,
@@ -93,6 +105,7 @@ SCM.DefaultClassConfig = {
 	spellConfig = {},
 	anchorConfig = {},
 	itemConfig = {},
+	customIcons = {},
 }
 
 SCM.Defaults.GlobalSettingsTabs = {

--- a/Database/loader.lua
+++ b/Database/loader.lua
@@ -19,6 +19,7 @@ function SCM.DB:RegisterClassConfig(classFileName, config)
 		anchorConfig = {},
 		spellConfig = {},
 		itemConfig = {},
+		customIcons = {},
 	}
 
 	for specID, anchorConfig in pairs(config.anchorConfig) do
@@ -35,6 +36,9 @@ function SCM.DB:RegisterClassConfig(classFileName, config)
 		if config.itemConfig then
 			self.classes[classFileName].itemConfig[specID] = config.itemConfig
 		end
+		if config.customIcons then
+			self.classes[classFileName].customIcons[specID] = config.customIcons[specID] or config.customIcons
+		end
 	end
 end
 
@@ -43,6 +47,7 @@ function SCM.DB:RegisterClassSpecConfig(classFileName, config, specID)
 		anchorConfig = {},
 		spellConfig = {},
 		itemConfig = {},
+		customIcons = {},
 	}
 
 	if config.anchorConfig[specID] then
@@ -56,6 +61,9 @@ function SCM.DB:RegisterClassSpecConfig(classFileName, config, specID)
 
 	if config.itemConfig then
 		self.classes[classFileName].itemConfig[specID] = config.itemConfig
+	end
+	if config.customIcons then
+		self.classes[classFileName].customIcons[specID] = config.customIcons[specID] or config.customIcons
 	end
 end
 

--- a/Options/cdm.lua
+++ b/Options/cdm.lua
@@ -13,8 +13,51 @@ local function SortByIndex(a, b)
 	return a.dataIndex < b.dataIndex
 end
 
-local function CreateAddSpellDropdown(owner, rootDescription, scrollFrame, anchorIndex)
+
+local function ShowNumericInputPopup(key, title, callback)
+	StaticPopupDialogs[key] = StaticPopupDialogs[key] or {
+		text = title,
+		button1 = ACCEPT,
+		button2 = CANCEL,
+		hasEditBox = true,
+		timeout = 0,
+		whileDead = true,
+		hideOnEscape = true,
+		preferredIndex = 3,
+		OnAccept = function(self)
+			local id = tonumber(self.editBox:GetText() or "")
+			if id and id > 0 then
+				callback(id)
+			end
+		end,
+	}
+	StaticPopup_Show(key)
+end
+
+local function CreateAddSpellDropdown(owner, rootDescription, scrollFrame, anchorIndex, isGlobal)
 	rootDescription:CreateTitle("Add Icon")
+
+	if isGlobal then
+		rootDescription:CreateButton("Custom Spell (SpellID)", function()
+			ShowNumericInputPopup("SCM_CUSTOM_SPELL_ID", "Enter Spell ID", function(spellID)
+				if C_Spell.GetSpellTexture(spellID) then
+					scrollFrame:AddCustomIcon({ texture = C_Spell.GetSpellTexture(spellID), spellID = spellID, iconType = "spell", id = "spell:" .. spellID, isCustom = true })
+					SCM:AddCustomIcon(anchorIndex, "spell", spellID, true)
+					SCM:ApplyAllCDManagerConfigs()
+				end
+			end)
+		end)
+		rootDescription:CreateButton("Custom Item (ItemID)", function()
+			ShowNumericInputPopup("SCM_CUSTOM_ITEM_ID", "Enter Item ID", function(itemID)
+				if C_Item.GetItemIconByID(itemID) then
+					scrollFrame:AddCustomIcon({ texture = C_Item.GetItemIconByID(itemID), spellID = 0, itemID = itemID, iconType = "item", id = "item:" .. itemID, isCustom = true })
+					SCM:AddCustomIcon(anchorIndex, "item", itemID, true)
+					SCM:ApplyAllCDManagerConfigs()
+				end
+			end)
+		end)
+		return
+	end
 
 	local dataProvider = CooldownViewerSettings:GetDataProvider()
 	local cooldownInfoByID = dataProvider and dataProvider.displayData.cooldownInfoByID
@@ -126,12 +169,55 @@ local function CreateAddSpellDropdown(owner, rootDescription, scrollFrame, ancho
 
 	ProcessAndCreateButtons(buffButton, buffItems, true)
 
+	rootDescription:CreateDivider()
+	rootDescription:CreateButton("Custom Spell (SpellID)", function()
+		ShowNumericInputPopup("SCM_CUSTOM_SPELL_ID", "Enter Spell ID", function(spellID)
+			local texture = C_Spell.GetSpellTexture(spellID)
+			if texture then
+				scrollFrame:AddCustomIcon({
+					spellID = spellID,
+					texture = texture,
+					isCustom = true,
+					iconType = "spell",
+					id = "spell:" .. spellID,
+				})
+				if isGlobal then
+					SCM:AddCustomIcon(anchorIndex, "spell", spellID, true)
+				else
+					SCM:AddCustomIcon(anchorIndex, "spell", spellID)
+				end
+				SCM:ApplyAllCDManagerConfigs()
+			end
+		end)
+	end)
+	rootDescription:CreateButton("Custom Item (ItemID)", function()
+		ShowNumericInputPopup("SCM_CUSTOM_ITEM_ID", "Enter Item ID", function(itemID)
+			local texture = C_Item.GetItemIconByID(itemID)
+			if texture then
+				local dataIndex = scrollFrame:AddCustomIcon({
+					spellID = 0,
+					texture = texture,
+					id = "item:" .. itemID,
+					isCustom = true,
+					iconType = "item",
+					itemID = itemID,
+				})
+				if isGlobal then
+					SCM:AddCustomIcon(anchorIndex, "item", itemID, true)
+				else
+					SCM:AddCustomIcon(anchorIndex, "item", itemID)
+				end
+				SCM:ApplyAllCDManagerConfigs()
+			end
+		end)
+	end)
+
 	for _, customEntry in pairs(SCM.CustomEntries) do
 		customEntry(rootDescription, scrollFrame, anchorIndex)
 	end
 end
 
-local function SelectRow(self, data, anchorIndex, rowIndex, rowTabsTbl)
+local function SelectRow(self, data, anchorIndex, rowIndex, rowTabsTbl, isGlobal)
 	self:ReleaseChildren()
 
 	if not data.rowConfig[rowIndex] then
@@ -192,7 +278,8 @@ local function SelectRow(self, data, anchorIndex, rowIndex, rowTabsTbl)
 	addRowButton:SetRelativeWidth(0.5)
 	addRowButton:SetDisabled(#rowTabsTbl >= 9)
 	addRowButton:SetCallback("OnClick", function()
-		local nextIndex = SCM:AddRow(anchorIndex)
+		local nextIndex = isGlobal and (#data.rowConfig + 1) or SCM:AddRow(anchorIndex)
+		if isGlobal then data.rowConfig[nextIndex] = { size = 40, limit = 8 } end
 
 		tinsert(rowTabsTbl, { value = nextIndex, text = "Row " .. nextIndex })
 		table.sort(rowTabsTbl, function(a, b)
@@ -209,7 +296,7 @@ local function SelectRow(self, data, anchorIndex, rowIndex, rowTabsTbl)
 	deleteRowButton:SetRelativeWidth(0.5)
 	deleteRowButton:SetDisabled(rowIndex == 1)
 	deleteRowButton:SetCallback("OnClick", function()
-		SCM:RemoveRow(anchorIndex, rowIndex)
+		if isGlobal then tremove(data.rowConfig, rowIndex) else SCM:RemoveRow(anchorIndex, rowIndex) end
 
 		local removedIndex
 		for i, tab in ipairs(rowTabsTbl) do
@@ -232,14 +319,15 @@ local function SelectRow(self, data, anchorIndex, rowIndex, rowTabsTbl)
 	buttonGroup:AddChild(deleteRowButton)
 end
 
-local function SelectAnchor(anchorWidget, frame, anchorIndex, anchorTabsTbl)
+local function SelectAnchor(anchorWidget, frame, anchorIndex, anchorTabsTbl, isGlobal)
 	anchorWidget:ReleaseChildren()
 	SCM.activeAnchorSettings = anchorIndex
 	local options = SCM.db.global.options
 
 	if options.showAnchorHighlight then
 		for group, anchorFrame in pairs(SCM.anchorFrames) do
-			if group == anchorIndex then
+			local activeGroup = isGlobal and (100 + anchorIndex) or anchorIndex
+			if group == activeGroup then
 				anchorFrame.isGlowActive = true
 				LibCustomGlow.PixelGlow_Stop(anchorFrame, "SCM")
 				LibCustomGlow.PixelGlow_Start(anchorFrame, { 0.34, 0.70, 0.91, 1 }, nil, nil, nil, nil, nil, nil, nil, "SCM")
@@ -253,7 +341,7 @@ local function SelectAnchor(anchorWidget, frame, anchorIndex, anchorTabsTbl)
 		end
 	end
 
-	local data = SCM.anchorConfig[anchorIndex]
+	local data = isGlobal and SCM.db.global.globalAnchorConfig[anchorIndex] or SCM.anchorConfig[anchorIndex]
 	if not data then
 		return
 	end
@@ -279,7 +367,7 @@ local function SelectAnchor(anchorWidget, frame, anchorIndex, anchorTabsTbl)
 	addAnchorButton:SetRelativeWidth(0.5)
 	addAnchorButton:SetDisabled(#anchorTabsTbl >= 15)
 	addAnchorButton:SetCallback("OnClick", function()
-		local nextIndex = SCM:AddAnchor(anchorTabsTbl, frame)
+		local nextIndex = isGlobal and SCM:AddGlobalAnchor(anchorTabsTbl) or SCM:AddAnchor(anchorTabsTbl, frame)
 		anchorWidget:SetTabs(anchorTabsTbl)
 		anchorWidget:SelectTab(nextIndex)
 	end)
@@ -288,9 +376,9 @@ local function SelectAnchor(anchorWidget, frame, anchorIndex, anchorTabsTbl)
 	local deleteAnchorButton = AceGUI:Create("Button")
 	deleteAnchorButton:SetText("Delete Anchor")
 	deleteAnchorButton:SetRelativeWidth(0.5)
-	deleteAnchorButton:SetDisabled(anchorIndex <= 3)
+	deleteAnchorButton:SetDisabled((not isGlobal and anchorIndex <= 3) or (isGlobal and anchorIndex == 1))
 	deleteAnchorButton:SetCallback("OnClick", function()
-		SCM:RemoveAnchor(anchorIndex, anchorTabsTbl)
+		if isGlobal then SCM:RemoveGlobalAnchor(anchorIndex, anchorTabsTbl) else SCM:RemoveAnchor(anchorIndex, anchorTabsTbl) end
 		anchorWidget:SetTabs(anchorTabsTbl)
 		anchorWidget:SelectTab(#anchorTabsTbl)
 	end)
@@ -382,7 +470,7 @@ local function SelectAnchor(anchorWidget, frame, anchorIndex, anchorTabsTbl)
 	rowTabs:SetFullWidth(true)
 	rowTabs:SetTabs(rowTabsTbl)
 	rowTabs:SetCallback("OnGroupSelected", function(self, event, rowIndex)
-		SelectRow(self, data, anchorIndex, rowIndex, rowTabsTbl)
+		SelectRow(self, data, anchorIndex, rowIndex, rowTabsTbl, isGlobal)
 	end)
 	rowTabs:SelectTab(1)
 	anchorOptions:AddChild(rowTabs)
@@ -412,7 +500,7 @@ local function SelectAnchor(anchorWidget, frame, anchorIndex, anchorTabsTbl)
 
 	horizontalScrollFrame:SetSortComparator(SortByIndex)
 
-	if SCM.spellConfig then
+	if not isGlobal and SCM.spellConfig then
 		local defaultCooldownViewerConfig = SCM.defaultCooldownViewerConfig
 		local spells = {}
 		for spellID, info in pairs(SCM.spellConfig) do
@@ -446,6 +534,22 @@ local function SelectAnchor(anchorWidget, frame, anchorIndex, anchorTabsTbl)
 			horizontalScrollFrame:AddSpellBySpellID(spellInfo.data, spellInfo.info.anchorGroup[anchorIndex].order, spellInfo.isBuffIcon)
 		end
 	end
+	local customCollection = isGlobal and SCM.db.global.globalCustomIcons or SCM.customIcons
+	for _, customIcon in ipairs(customCollection or {}) do
+		if customIcon.anchorGroup == anchorIndex then
+			local texture = customIcon.iconType == "spell" and C_Spell.GetSpellTexture(customIcon.spellID) or C_Item.GetItemIconByID(customIcon.itemID)
+			if texture or SCM.isOptionsOpen then
+				horizontalScrollFrame:AddCustomIcon({
+					texture = texture or 134400,
+					spellID = customIcon.spellID or 0,
+					itemID = customIcon.itemID,
+					iconType = customIcon.iconType,
+					id = customIcon.id,
+				})
+			end
+		end
+	end
+
 	horizontalScrollFrame:AddAddButton()
 
 	local customSpellSettings = AceGUI:Create("InlineGroup")
@@ -474,7 +578,7 @@ local function SelectAnchor(anchorWidget, frame, anchorIndex, anchorTabsTbl)
 		if button == "LeftButton" then
 			if buttonFrame.data.isAddButton then
 				local menu = MenuUtil.CreateContextMenu(nil, function(owner, rootDescription)
-					CreateAddSpellDropdown(owner, rootDescription, horizontalScrollFrame, anchorIndex)
+					CreateAddSpellDropdown(owner, rootDescription, horizontalScrollFrame, anchorIndex, isGlobal)
 				end)
 			else
 				if not lastButtonFrame or lastButtonFrame ~= buttonFrame then
@@ -576,7 +680,11 @@ local function SelectAnchor(anchorWidget, frame, anchorIndex, anchorTabsTbl)
 		elseif button == "RightButton" and not buttonFrame.data.isAddButton then
 			local menu = MenuUtil.CreateContextMenu(nil, function(owner, rootDescription)
 				rootDescription:CreateButton("Remove", function()
-					SCM:RemoveSpellFromConfig(anchorIndex, buttonFrame.data)
+					if buttonFrame.data.isCustom then
+						SCM:RemoveCustomIcon(anchorIndex, buttonFrame.data.id, isGlobal)
+					else
+						SCM:RemoveSpellFromConfig(anchorIndex, buttonFrame.data)
+					end
 					horizontalScrollFrame:RemoveButton(buttonFrame.data)
 					SCM:ApplyAllCDManagerConfigs()
 				end)
@@ -619,29 +727,43 @@ local function SelectAnchor(anchorWidget, frame, anchorIndex, anchorTabsTbl)
 	--self:AddChild(label)
 end
 
-local function CDM(self, frame, group)
+local function CreateAnchorTabGroup(parent, frame, isGlobal)
 	local anchorTabs = AceGUI:Create("TabGroup")
 	anchorTabs:SetLayout("fill")
 	anchorTabs:SetFullWidth(true)
 	anchorTabs:SetFullHeight(true)
-	anchorTabs.frame:SetPoint("TOPLEFT", self.frame, "TOPLEFT", 0, -30)
-	anchorTabs.frame:SetPoint("BOTTOMRIGHT", self.frame, "BOTTOMRIGHT", 0, -5)
-	anchorTabs.frame:SetParent(self.frame)
-	anchorTabs.frame:Show()
 
+	local sourceConfig = isGlobal and SCM.db.global.globalAnchorConfig or SCM.anchorConfig
 	local anchorTabsTbl = {}
-	for i, anchor in ipairs(SCM.anchorConfig) do
+	for i in ipairs(sourceConfig) do
 		tinsert(anchorTabsTbl, { value = i, text = "Anchor " .. i })
 	end
 
 	anchorTabs:SetTabs(anchorTabsTbl)
 	anchorTabs:SetCallback("OnGroupSelected", function(self, event, anchorIndex)
-		SelectAnchor(self, frame, anchorIndex, anchorTabsTbl)
+		SelectAnchor(self, frame, anchorIndex, anchorTabsTbl, isGlobal)
 	end)
 	anchorTabs:SelectTab(1)
-	self:AddChild(anchorTabs)
+	parent:AddChild(anchorTabs)
+end
 
-	self.typeTab = anchorTabs
+local function CDM(self, frame, group)
+	local modeTabs = AceGUI:Create("TabGroup")
+	modeTabs:SetLayout("fill")
+	modeTabs:SetFullWidth(true)
+	modeTabs:SetFullHeight(true)
+	modeTabs:SetTabs({
+		{ value = "spec", text = "Spec Anchors" },
+		{ value = "global", text = "Global Anchors" },
+	})
+	modeTabs:SetCallback("OnGroupSelected", function(widget, event, mode)
+		widget:ReleaseChildren()
+		CreateAnchorTabGroup(widget, frame, mode == "global")
+	end)
+	modeTabs:SelectTab("spec")
+	self:AddChild(modeTabs)
+
+	self.typeTab = modeTabs
 end
 
 SCM.MainTabs.CDM.callback = CDM

--- a/Options/options.lua
+++ b/Options/options.lua
@@ -19,6 +19,47 @@ function SCM.Decode(importString)
 	return data
 end
 
+function SCM:AddGlobalAnchor(anchorTabsTbl)
+	local anchorConfig = self.db.global.globalAnchorConfig
+	local nextIndex = #anchorConfig + 1
+	anchorConfig[nextIndex] = {
+		anchor = { "CENTER", "UIParent", "CENTER", 0, 0 },
+		rowConfig = {
+			[1] = {
+				size = 40,
+				limit = 8,
+			},
+		},
+	}
+	tinsert(anchorTabsTbl, { value = nextIndex, text = "Anchor " .. nextIndex })
+	SCM:ApplyAllCDManagerConfigs()
+	return nextIndex
+end
+
+function SCM:RemoveGlobalAnchor(anchorIndex, anchorTabsTbl)
+	if self.db.global.globalAnchorConfig[anchorIndex] then
+		tremove(self.db.global.globalAnchorConfig, anchorIndex)
+	end
+	for i = #self.db.global.globalCustomIcons, 1, -1 do
+		local cfg = self.db.global.globalCustomIcons[i]
+		if cfg.anchorGroup == anchorIndex then
+			tremove(self.db.global.globalCustomIcons, i)
+		elseif cfg.anchorGroup and cfg.anchorGroup > anchorIndex then
+			cfg.anchorGroup = cfg.anchorGroup - 1
+		end
+	end
+	for i = #anchorTabsTbl, 1, -1 do
+		if anchorTabsTbl[i].value == anchorIndex then
+			tremove(anchorTabsTbl, i)
+		end
+	end
+	for i, tab in ipairs(anchorTabsTbl) do
+		tab.value = i
+		tab.text = "Anchor " .. i
+	end
+	SCM:ApplyAllCDManagerConfigs()
+end
+
 function SCM:AddAnchor(anchorTabsTbl, frame)
 	local nextIndex = #SCM.anchorConfig + 1
 	self.anchorConfig[nextIndex] = {
@@ -102,6 +143,45 @@ function SCM:RemoveRow(anchorIndex, rowIndex)
 	end
 end
 
+
+function SCM:AddCustomIcon(anchorGroup, iconType, idValue, isGlobal)
+	local dbTable = isGlobal and self.db.global.globalCustomIcons or self.customIcons
+	if not dbTable then
+		return
+	end
+
+	local nextOrder = 1
+	for _, entry in ipairs(dbTable) do
+		if entry.anchorGroup == anchorGroup and (entry.order or 0) >= nextOrder then
+			nextOrder = (entry.order or 0) + 1
+		end
+	end
+
+	tinsert(dbTable, {
+		id = (iconType == "item" and "item:" or "spell:") .. idValue,
+		iconType = iconType,
+		spellID = iconType == "spell" and idValue or nil,
+		itemID = iconType == "item" and idValue or nil,
+		anchorGroup = anchorGroup,
+		order = nextOrder,
+	})
+end
+
+function SCM:RemoveCustomIcon(anchorGroup, id, isGlobal)
+	local dbTable = isGlobal and self.db.global.globalCustomIcons or self.customIcons
+	if not dbTable then
+		return
+	end
+
+	for i = #dbTable, 1, -1 do
+		local entry = dbTable[i]
+		if entry.anchorGroup == anchorGroup and entry.id == id then
+			tremove(dbTable, i)
+			break
+		end
+	end
+end
+
 function SCM:AddSpellToConfig(anchorGroup, order, info, displayData, sourceIndex)
 	if not self.spellConfig[displayData.spellID] then
 		self.spellConfig[displayData.spellID] = {
@@ -180,6 +260,7 @@ end
 
 local function OpenOptions()
 	local options = SCM.db.global.options
+	SCM.isOptionsOpen = true
 
 	SCM:StopAllGlows()
 
@@ -224,6 +305,7 @@ local function OpenOptions()
 	tabs:SelectTab("General")
 	frame:AddChild(tabs)
 	frame:SetCallback("OnClose", function()
+		SCM.isOptionsOpen = nil
 		for _, anchorFrame in pairs(SCM.anchorFrames) do
 			anchorFrame.debugTexture:Hide()
 			anchorFrame.debugText:Hide()

--- a/core.lua
+++ b/core.lua
@@ -1,6 +1,7 @@
 local addonName, SCM = ...
 SCM.anchorFrames = {}
 SCM.itemFrames = {}
+SCM.customIconFrames = {}
 SCM.MainTabs = {}
 SCM.OptionsCallbacks = {}
 SCM.Skins = {}
@@ -35,6 +36,20 @@ local PIVOT_MAP = {
 		RIGHT = "LEFT",
 	},
 }
+
+local function ToGlobalGroup(index)
+	return 100 + (index or 1)
+end
+
+local function GetAnchorConfigForGroup(config, group)
+	if config and config.anchorConfig and config.anchorConfig[group] then
+		return config.anchorConfig[group]
+	end
+
+	if SCM.globalAnchorConfig and group >= 100 then
+		return SCM.globalAnchorConfig[group - 100]
+	end
+end
 
 local function SortBySCMOrder(a, b)
 	return (a.SCMOrder or 0) < (b.SCMOrder or 0)
@@ -383,6 +398,105 @@ local function HideItemIcons()
 	end
 end
 
+local function GetCurveCharges(spellID)
+	local charges = 0
+	if SCM.GetSpellChargesFromCurve then
+		charges = SCM:GetSpellChargesFromCurve(spellID) or 0
+	elseif C_Spell and C_Spell.GetSpellCharges then
+		local chargeInfo = C_Spell.GetSpellCharges(spellID)
+		charges = chargeInfo and chargeInfo.currentCharges or 0
+	end
+	return charges
+end
+
+function SCM:GetSpellChargesFromCurve(spellID)
+	if CooldownViewerManager and CooldownViewerManager.GetSecretChargesCurveValue then
+		local ok, value = pcall(CooldownViewerManager.GetSecretChargesCurveValue, CooldownViewerManager, spellID)
+		if ok and type(value) == "number" then
+			return value
+		end
+	end
+end
+
+local function SetCustomIconCountText(frame, iconType, id)
+	frame.SpellChargesText:SetText("")
+	frame.ItemCountText:SetText("")
+	frame.SpellChargesText:Hide()
+	frame.ItemCountText:Hide()
+
+	if iconType == "spell" then
+		local charges = GetCurveCharges(id)
+		if charges and charges > 0 then
+			frame.SpellChargesText:SetText(charges)
+			frame.SpellChargesText:Show()
+		end
+	else
+		local count = C_Item and C_Item.GetItemCount and C_Item.GetItemCount(id, false, false, true) or GetItemCount(id, false, false)
+		if count and count > 0 then
+			frame.ItemCountText:SetText(count)
+			frame.ItemCountText:Show()
+		end
+	end
+end
+
+local function ProcessCustomIcons(iconConfig, validChildren, isGlobal)
+	for index, config in ipairs(iconConfig or {}) do
+		local frameID = (isGlobal and "global:" or "spec:") .. (config.id or tostring(index))
+		local frame = SCM.customIconFrames[frameID] or CreateFrame("Frame", nil, UIParent, "PermokItemIconTemplate")
+		SCM.customIconFrames[frameID] = frame
+		frame:SetScale(cachedViewerScale)
+		frame.SCMConfig = config
+		frame.SCMOrder = config.order or index
+		frame.SCMCooldownID = frameID
+		frame.SCMSpellID = config.spellID
+
+		local iconType = config.iconType or (config.spellID and "spell") or "item"
+		local iconTexture
+		if iconType == "spell" and config.spellID then
+			iconTexture = C_Spell.GetSpellTexture(config.spellID)
+			frame.SCMSpellID = config.spellID
+		elseif iconType == "item" and config.itemID then
+			iconTexture = C_Item.GetItemIconByID(config.itemID)
+		end
+
+		if SCM.isOptionsOpen and not iconTexture then
+			iconTexture = 134400
+		end
+
+		local shouldShow = iconTexture ~= nil
+		if shouldShow then
+			frame.Icon:SetTexture(iconTexture)
+			SetCustomIconCountText(frame, iconType, config.spellID or config.itemID)
+			frame:Show()
+			SCM:SkinChild(frame, config)
+			local anchor = config.anchorGroup or 1
+			if isGlobal then
+				anchor = ToGlobalGroup(anchor)
+			end
+			validChildren[anchor] = validChildren[anchor] or {}
+			tinsert(validChildren[anchor], frame)
+		else
+			frame:Hide()
+		end
+	end
+end
+
+local function HideUnusedCustomIcons(specConfig, globalConfig)
+	local keep = {}
+	for _, cfg in ipairs(specConfig or {}) do
+		keep["spec:" .. (cfg.id or "")] = true
+	end
+	for _, cfg in ipairs(globalConfig or {}) do
+		keep["global:" .. (cfg.id or "")] = true
+	end
+
+	for id, frame in pairs(SCM.customIconFrames) do
+		if not keep[id] then
+			frame:Hide()
+		end
+	end
+end
+
 local function OrderCDManagerSpells_Actual()
 	cachedViewerScale = 1
 
@@ -415,8 +529,12 @@ local function OrderCDManagerSpells_Actual()
 		HideItemIcons()
 	end
 
+	ProcessCustomIcons(SCM.customIcons, cachedCooldownFrameTbl, false)
+	ProcessCustomIcons(SCM.globalCustomIcons, cachedCooldownFrameTbl, true)
+	HideUnusedCustomIcons(SCM.customIcons, SCM.globalCustomIcons)
+
 	for group, visibleChildren in pairs(cachedCooldownFrameTbl) do
-		local anchorConfig = config and config.anchorConfig and config.anchorConfig[group]
+		local anchorConfig = GetAnchorConfigForGroup(config, group)
 		local rowConfig = (anchorConfig and anchorConfig.rowConfig and #anchorConfig.rowConfig > 0) and anchorConfig.rowConfig or DEFAULT_ROW_CONFIG
 		local lastRowConfig = rowConfig[#rowConfig]
 		local growDir = anchorConfig and anchorConfig.grow or "CENTER"
@@ -555,7 +673,15 @@ local function OrderCDManagerSpells_Actual()
 		end
 	end
 
+	local allAnchors = {}
 	for group, anchorConfig in pairs(config.anchorConfig) do
+		allAnchors[group] = anchorConfig
+	end
+	for index, anchorConfig in pairs(SCM.globalAnchorConfig or {}) do
+		allAnchors[ToGlobalGroup(index)] = anchorConfig
+	end
+
+	for group, anchorConfig in pairs(allAnchors) do
 		if not cachedCooldownFrameTbl[group] then
 			local rowConfig = anchorConfig.rowConfig
 
@@ -876,6 +1002,7 @@ function SCM:UpdateDB()
 	local specAnchorConfig = currentConfig and currentConfig.anchorConfig[specID]
 	local specSpellConfig = currentConfig and currentConfig.spellConfig[specID]
 	local itemConfig = currentConfig and currentConfig.itemConfig and currentConfig.itemConfig[specID]
+	local customIcons = currentConfig and currentConfig.customIcons and currentConfig.customIcons[specID]
 
 	self.db.profile[class] = self.db.profile[class] or {}
 	self.db.profile[class][specID] = self.db.profile[class][specID]
@@ -883,12 +1010,17 @@ function SCM:UpdateDB()
 			anchorConfig = CopyTable(specAnchorConfig or self.DB.defaultAnchorConfig),
 			itemConfig = itemConfig or {},
 			spellConfig = specSpellConfig or {},
+			customIcons = customIcons or {},
 		}
 
 	self.currentConfig = self.db.profile[class][specID]
+	self.currentConfig.customIcons = self.currentConfig.customIcons or {}
 	self.anchorConfig = self.currentConfig.anchorConfig
 	self.spellConfig = self.currentConfig.spellConfig
 	self.itemConfig = self.currentConfig.itemConfig
+	self.customIcons = self.currentConfig.customIcons
+	self.globalAnchorConfig = self.db.global.globalAnchorConfig or {}
+	self.globalCustomIcons = self.db.global.globalCustomIcons or {}
 end
 
 function SCM:SetHooks()
@@ -945,6 +1077,10 @@ function SCM:PLAYER_ENTERING_WORLD(isInitialLogin, isReload)
 	end
 
 	self.isInInstance = IsInInstance()
+end
+
+function SCM:BAG_UPDATE_DELAYED()
+	SCM:ApplyAllCDManagerConfigs()
 end
 
 function SCM:BAG_UPDATE_COOLDOWN()
@@ -1039,6 +1175,7 @@ EventUtil.ContinueOnAddOnLoaded(addonName, function()
 	eventFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
 	eventFrame:RegisterEvent("PLAYER_REGEN_DISABLED")
 	eventFrame:RegisterEvent("BAG_UPDATE_COOLDOWN")
+	eventFrame:RegisterEvent("BAG_UPDATE_DELAYED")
 	eventFrame:RegisterEvent("TRAIT_CONFIG_UPDATED")
 	eventFrame:RegisterEvent("ACTIVE_PLAYER_SPECIALIZATION_CHANGED")
 	eventFrame:RegisterEvent("EDIT_MODE_LAYOUTS_UPDATED")

--- a/profiles.lua
+++ b/profiles.lua
@@ -11,6 +11,7 @@ local function MergeConfig(destDB, sourceData, defaultAnchor)
 
 	destDB.spellConfig = sourceData.spellConfig
 	destDB.itemConfig = sourceData.itemConfig
+	destDB.customIcons = sourceData.customIcons or {}
 
 	local anchors = sourceData.anchorConfig
 	if not anchors or #anchors == 0 then

--- a/templates.xml
+++ b/templates.xml
@@ -56,6 +56,16 @@
 					</Anchors>
 					<TexCoords left="0.12" right="0.88" top="0.12" bottom="0.88"/>
 				</Texture>
+				<FontString name="$parentSpellChargesText" parentKey="SpellChargesText" inherits="NumberFontNormalLarge" justifyH="RIGHT" text="">
+					<Anchors>
+						<Anchor point="BOTTOMRIGHT" x="-4" y="5"/>
+					</Anchors>
+				</FontString>
+				<FontString name="$parentItemCountText" parentKey="ItemCountText" inherits="NumberFontNormalLarge" justifyH="RIGHT" text="">
+					<Anchors>
+						<Anchor point="BOTTOMRIGHT" x="-4" y="5"/>
+					</Anchors>
+				</FontString>
 			</Layer>
 		</Layers>
 		<Frames>


### PR DESCRIPTION
### Motivation
- Add the ability to place arbitrary custom spell/item icons into the Cooldown Manager (CDM) UI for both spec-scoped anchors and global anchors. 
- Show spell charges and item counts on custom icons (only when > 0) including a pathway to read secret/curve-based charges from Midnight/CooldownViewer. 
- Keep global anchors distinct from per-spec anchors and allow editing/visualizing global anchors from the CDM options. 
- Provide usable placeholders while the options window is open so authors can add icons before textures are available.

### Description
- Added DB defaults and per-class/spec wiring for `customIcons` and `globalCustomIcons` and a `globalAnchorConfig` default (`Database/defaults.lua`, `Database/loader.lua`, `profiles.lua`).
- Implemented CRUD helpers and UI hooks: `SCM:AddCustomIcon`, `SCM:RemoveCustomIcon`, `SCM:AddGlobalAnchor`, and `SCM:RemoveGlobalAnchor` and wired them into options (`Options/options.lua`, `Options/cdm.lua`).
- Extended CDM options with two tabs — `Spec Anchors` and `Global Anchors` — and numeric-ID popups to add custom spell/item icons; global anchors only list/allow custom icons (`Options/cdm.lua`).
- Added runtime custom-icon handling and rendering in `core.lua`: custom icon frame pool, `ProcessCustomIcons`, mapping global anchors into a separate namespace (`100 + index`), and selective display of `SpellChargesText` / `ItemCountText`; only show counts > 0 and use `CooldownViewerManager.GetSecretChargesCurveValue` as a curve-based fallback for charges.
- Made the horizontal scroll widget able to insert custom icon entries by adding `AddCustomIcon` and bumped its widget version (`Custom-Widgets/AceGUIContainer-SCMHorizontalScrollFrame.lua`).
- Updated UI template `PermokItemIconTemplate` to include `SpellChargesText` and `ItemCountText` so the icon can show either charges or bag count depending on icon type (`templates.xml`).
- Added a lightweight refresh path for bag/charge changes and a flag `SCM.isOptionsOpen` to show dummy icons while options are visible so anchors appear in the editor even if textures/secret data are unavailable (`core.lua`, `Options/options.lua`).

### Testing
- Ran `git diff --check` to ensure no whitespace/diff problems; it succeeded. 
- Verified repository status with `git status --short` and confirmed the intended files were modified; the check succeeded. 
- Performed a commit and inspected the commit summary with `git show --stat` to confirm the change set; the commit succeeded. 
- No automated in-game unit tests were added; runtime behavior should be validated in-game (options flow, adding custom icons, and verifying counts/charges visibility > 0).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999ec4172388321aae2a4e7464ed581)