### PR TITLE
Fix spell known typo and check nil on Load Conditions

### DIFF
--- a/Options/cdm.lua
+++ b/Options/cdm.lua
@@ -1595,7 +1595,7 @@ local function SelectAnchor(widget, parentWidget, anchorIndex, anchorTabsTbl, mo
 										iconSettingsTabs:AddChild(loadRaces)
 
 										local useSpellKnown = AceGUI:Create("CheckBox")
-										useSpellKnown:SetLabel("Race")
+										useSpellKnown:SetLabel("Spell Known")
 										useSpellKnown:SetRelativeWidth(0.5)
 										useSpellKnown:SetValue(buttonConfig.useSpellKnown)
 										iconSettingsTabs:AddChild(useSpellKnown)
@@ -1603,7 +1603,7 @@ local function SelectAnchor(widget, parentWidget, anchorIndex, anchorTabsTbl, mo
 										local loadSpellKnown = AceGUI:Create("EditBox")
 										loadSpellKnown:SetRelativeWidth(0.5)
 										loadSpellKnown:SetLabel("SpellID")
-										loadSpellKnown:SetText(tostring(buttonConfig.spellKnownSpellID) or "")
+										loadSpellKnown:SetText(buttonConfig.spellKnownSpellID and tostring(buttonConfig.spellKnownSpellID) or "")
 										loadSpellKnown:SetDisabled(not buttonConfig.useSpellKnown)
 										loadSpellKnown:SetCallback("OnEnterPressed", function(_, _, value)
 											buttonConfig.spellKnownSpellID = tonumber(value)

--- a/Options/cdm.lua
+++ b/Options/cdm.lua
@@ -1602,7 +1602,7 @@ local function SelectAnchor(widget, parentWidget, anchorIndex, anchorTabsTbl, mo
 
 										local loadSpellKnown = AceGUI:Create("EditBox")
 										loadSpellKnown:SetRelativeWidth(0.5)
-										loadSpellKnown:SetLabel("SpellID")
+										loadSpellKnown:SetLabel("Spell ID")
 										loadSpellKnown:SetText(buttonConfig.spellKnownSpellID and tostring(buttonConfig.spellKnownSpellID) or "")
 										loadSpellKnown:SetDisabled(not buttonConfig.useSpellKnown)
 										loadSpellKnown:SetCallback("OnEnterPressed", function(_, _, value)


### PR DESCRIPTION
I found a small bug, but it's annoying, so I put up a small PR to fix it

Before
<img width="1627" height="1012" alt="before" src="https://github.com/user-attachments/assets/c7ecff6a-73d8-4a4d-b30d-a6389029a7a4" />

After
<img width="1590" height="963" alt="after" src="https://github.com/user-attachments/assets/7b8724b6-8af4-4e35-ab6b-2e7982b6f5bb" />
