### PR TITLE
Add public anchor layout callbacks

### DIFF
--- a/Database/defaults.lua
+++ b/Database/defaults.lua
@@ -125,6 +125,7 @@ SCM.DefaultDB = {
 			borderSize = 1,
 			anchorUUF = false,
 			anchorElvUI = false,
+			anchorLayoutCallbacks = {},
 			temporaryPadding = 0,
 			adjustHeight = true,
 			anchorsHeightOffset = 0,

--- a/Modules/anchors.lua
+++ b/Modules/anchors.lua
@@ -3,6 +3,276 @@ local SCM = select(2, ...)
 local Utils = SCM.Utils
 local OriginalElvUIAnchors = {}
 
+local function GetAnchorLayoutCallbackSettings()
+	local profileOptions = SCM.db and SCM.db.profile and SCM.db.profile.options
+	if not profileOptions then
+		return
+	end
+
+	profileOptions.anchorLayoutCallbacks = profileOptions.anchorLayoutCallbacks or {}
+	return profileOptions.anchorLayoutCallbacks
+end
+
+local function NormalizeAnchorLayoutGroups(groups)
+	if groups == nil then
+		return
+	end
+
+	if type(groups) == "number" then
+		return { [groups] = true }
+	end
+
+	if type(groups) ~= "table" then
+		return
+	end
+
+	local normalizedGroups = {}
+	for key, value in pairs(groups) do
+		if type(key) == "number" and value then
+			normalizedGroups[key] = true
+		elseif type(value) == "number" then
+			normalizedGroups[value] = true
+		end
+	end
+
+	if next(normalizedGroups) then
+		return normalizedGroups
+	end
+end
+
+local function CopyAnchorLayoutRoles(roles)
+	if type(roles) ~= "table" then
+		return
+	end
+
+	local copiedRoles = {}
+	for role, enabled in pairs(roles) do
+		copiedRoles[role] = enabled and true or false
+	end
+	return copiedRoles
+end
+
+local function GetAnchorLayoutCallbackConfig(addOnName, callbackEntry)
+	local settings = GetAnchorLayoutCallbackSettings()
+	if not settings then
+		return
+	end
+
+	local config = settings[addOnName]
+	if type(config) ~= "table" then
+		config = { enabled = config }
+		settings[addOnName] = config
+	end
+
+	if config.enabled == nil then
+		config.enabled = callbackEntry.defaultEnabled
+	end
+	if callbackEntry.roles and type(config.roles) ~= "table" then
+		config.roles = CopyAnchorLayoutRoles(callbackEntry.roles)
+	end
+
+	return config
+end
+
+local function RemoveAnchorLayoutCallbackOrder(addOnName)
+	for index = #SCM.AnchorLayoutCallbackOrder, 1, -1 do
+		if SCM.AnchorLayoutCallbackOrder[index] == addOnName then
+			tremove(SCM.AnchorLayoutCallbackOrder, index)
+		end
+	end
+end
+
+function SCM:RegisterAnchorLayoutCallback(addOnName, callback, callbackOptions, override)
+	if type(addOnName) ~= "string" or addOnName == "" or type(callback) ~= "function" then
+		return false
+	end
+
+	local callbacks = self.AnchorLayoutCallbacks
+	if callbacks[addOnName] and not override then
+		return false
+	end
+
+	callbackOptions = type(callbackOptions) == "table" and callbackOptions or {}
+
+	if not callbacks[addOnName] then
+		tinsert(self.AnchorLayoutCallbackOrder, addOnName)
+	end
+
+	callbacks[addOnName] = {
+		activeGroups = {},
+		callback = callback,
+		defaultEnabled = callbackOptions.defaultEnabled ~= false,
+		displayName = callbackOptions.displayName or addOnName,
+		groups = NormalizeAnchorLayoutGroups(callbackOptions.groups or callbackOptions.group),
+		roles = CopyAnchorLayoutRoles(callbackOptions.roles),
+	}
+
+	GetAnchorLayoutCallbackConfig(addOnName, callbacks[addOnName])
+
+	for group, state in pairs(self.AnchorLayoutState) do
+		self:NotifyAnchorLayoutCallback(addOnName, callbacks[addOnName], group, state)
+	end
+
+	return true
+end
+
+function SCM:UnregisterAnchorLayoutCallback(addOnName)
+	local callbacks = self.AnchorLayoutCallbacks
+	local callbackEntry = callbacks[addOnName]
+	if not callbackEntry then
+		return false
+	end
+
+	for group, state in pairs(self.AnchorLayoutState) do
+		self:NotifyAnchorLayoutCallback(addOnName, callbackEntry, group, state, false)
+	end
+
+	callbacks[addOnName] = nil
+	RemoveAnchorLayoutCallbackOrder(addOnName)
+	return true
+end
+
+function SCM:GetAnchorLayoutCallbacks()
+	return self.AnchorLayoutCallbacks, self.AnchorLayoutCallbackOrder
+end
+
+function SCM:IsAnchorLayoutCallbackEnabled(addOnName)
+	local callbackEntry = self.AnchorLayoutCallbacks[addOnName]
+	if not callbackEntry then
+		return false
+	end
+
+	local config = GetAnchorLayoutCallbackConfig(addOnName, callbackEntry)
+	if not config then
+		return callbackEntry.defaultEnabled
+	end
+
+	return config.enabled and true or false
+end
+
+function SCM:GetAnchorLayoutCallbackRoles(addOnName)
+	local callbackEntry = self.AnchorLayoutCallbacks[addOnName]
+	if not (callbackEntry and callbackEntry.roles) then
+		return
+	end
+
+	local config = GetAnchorLayoutCallbackConfig(addOnName, callbackEntry)
+	return config and config.roles or callbackEntry.roles
+end
+
+function SCM:IsAnchorLayoutCallbackRoleEnabled(addOnName)
+	local callbackEntry = self.AnchorLayoutCallbacks[addOnName]
+	if not callbackEntry then
+		return false
+	end
+	if not callbackEntry.roles then
+		return true
+	end
+
+	local roles = self:GetAnchorLayoutCallbackRoles(addOnName)
+	local currentRole = select(5, Utils.GetSpec())
+	return roles and roles[currentRole] == true or false
+end
+
+function SCM:SetAnchorLayoutCallbackEnabled(addOnName, enabled)
+	local callbackEntry = self.AnchorLayoutCallbacks[addOnName]
+	if not callbackEntry then
+		return false
+	end
+
+	local config = GetAnchorLayoutCallbackConfig(addOnName, callbackEntry)
+	if config then
+		config.enabled = enabled and true or false
+	end
+
+	if not enabled then
+		for group, state in pairs(self.AnchorLayoutState) do
+			self:NotifyAnchorLayoutCallback(addOnName, callbackEntry, group, state, false)
+		end
+	else
+		for group, state in pairs(self.AnchorLayoutState) do
+			self:NotifyAnchorLayoutCallback(addOnName, callbackEntry, group, state)
+		end
+	end
+
+	return true
+end
+
+function SCM:SetAnchorLayoutCallbackRoleEnabled(addOnName, role, enabled)
+	local callbackEntry = self.AnchorLayoutCallbacks[addOnName]
+	if not (callbackEntry and callbackEntry.roles) then
+		return false
+	end
+
+	local config = GetAnchorLayoutCallbackConfig(addOnName, callbackEntry)
+	if not config then
+		return false
+	end
+
+	config.roles[role] = enabled and true or false
+	for group, state in pairs(self.AnchorLayoutState) do
+		self:NotifyAnchorLayoutCallback(addOnName, callbackEntry, group, state)
+	end
+
+	return true
+end
+
+function SCM:NotifyAnchorLayoutCallback(addOnName, callbackEntry, group, state, enabled)
+	if not callbackEntry or not state then
+		return
+	end
+
+	if enabled == nil then
+		enabled = self:IsAnchorLayoutCallbackEnabled(addOnName) and self:IsAnchorLayoutCallbackRoleEnabled(addOnName)
+	end
+
+	local groups = callbackEntry.groups
+	if enabled and groups and not groups[group] then
+		return
+	end
+
+	local activeGroups = callbackEntry.activeGroups
+	if not enabled and not activeGroups[group] then
+		return
+	end
+
+	local ok, err = pcall(
+		callbackEntry.callback,
+		group,
+		state.anchorFrame,
+		state.effectiveWidth,
+		state.effectiveHeight,
+		state.rowConfig,
+		state.options,
+		enabled
+	)
+
+	activeGroups[group] = enabled and ok or nil
+	callbackEntry.lastError = not ok and err or nil
+
+	if not ok then
+		self:Debug("Anchor layout callback failed", addOnName, err)
+	end
+end
+
+function SCM:NotifyAnchorLayoutCallbacks(group, anchorFrame, effectiveWidth, effectiveHeight, rowConfig, options)
+	local state = self.AnchorLayoutState[group]
+	if not state then
+		state = {}
+		self.AnchorLayoutState[group] = state
+	end
+
+	state.anchorFrame = anchorFrame
+	state.effectiveWidth = effectiveWidth
+	state.effectiveHeight = effectiveHeight
+	state.rowConfig = rowConfig
+	state.options = options
+
+	for _, addOnName in ipairs(self.AnchorLayoutCallbackOrder) do
+		self:NotifyAnchorLayoutCallback(addOnName, self.AnchorLayoutCallbacks[addOnName], group, state)
+	end
+end
+
 local function OnResourceBarWidthChanged(self)
 	UIParent.SetWidth(self, self.SCMWidth)
 end

--- a/Modules/cdm.lua
+++ b/Modules/cdm.lua
@@ -542,6 +542,8 @@ local function LayoutAnchorGroup(group, visibleChildren, anchorConfig, options, 
 
 			SCM:UpdateUUFValues(options, effectiveWidth, rowConfig)
 		end
+
+		SCM:NotifyAnchorLayoutCallbacks(group, groupAnchor, effectiveWidth, effectiveHeight, rowConfig, options)
 	end
 
 	if group == 1 then

--- a/Options/temporary.lua
+++ b/Options/temporary.lua
@@ -1,7 +1,88 @@
 local SCM = select(2, ...)
 local AceGUI = LibStub("AceGUI-3.0")
 
-SCM.MainTabs.Temporary = { value = "Temporary", text = "Temporary", order = 8, subgroups = {} }
+SCM.MainTabs.Temporary = { value = "Temporary", text = "Integrations", order = 8, subgroups = {} }
+
+local function AddAnchorLayoutCallbackSettings(parent)
+	local anchorLayoutSettings = AceGUI:Create("InlineGroup")
+	anchorLayoutSettings:SetLayout("flow")
+	anchorLayoutSettings:SetFullWidth(true)
+	anchorLayoutSettings:SetTitle("Public Anchor Integrations")
+	parent:AddChild(anchorLayoutSettings)
+
+	local listContainer = AceGUI:Create("SimpleGroup")
+	listContainer:SetLayout("flow")
+	listContainer:SetFullWidth(true)
+
+	local function RefreshList()
+		listContainer:ReleaseChildren()
+
+		local callbacks, callbackOrder = SCM:GetAnchorLayoutCallbacks()
+		if not callbackOrder or #callbackOrder == 0 then
+			local emptyLabel = AceGUI:Create("Label")
+			emptyLabel:SetRelativeWidth(1)
+			emptyLabel:SetText("No public anchor integrations are registered.")
+			listContainer:AddChild(emptyLabel)
+		else
+			for _, addOnName in ipairs(callbackOrder) do
+				local callbackEntry = callbacks[addOnName]
+				if callbackEntry then
+					local row = AceGUI:Create("SimpleGroup")
+					row:SetLayout("flow")
+					row:SetFullWidth(true)
+					listContainer:AddChild(row)
+
+					local enabled = AceGUI:Create("CheckBox")
+					enabled:SetRelativeWidth(0.55)
+					enabled:SetLabel(callbackEntry.displayName or addOnName)
+					enabled:SetValue(SCM:IsAnchorLayoutCallbackEnabled(addOnName))
+					enabled:SetCallback("OnValueChanged", function(_, _, value)
+						SCM:SetAnchorLayoutCallbackEnabled(addOnName, value)
+						SCM:ApplyAllCDManagerConfigs()
+						RefreshList()
+					end)
+					row:AddChild(enabled)
+
+					local roles = SCM:GetAnchorLayoutCallbackRoles(addOnName)
+					if roles then
+						local roleDropdown = AceGUI:Create("Dropdown")
+						roleDropdown:SetRelativeWidth(0.3)
+						roleDropdown:SetLabel("Roles")
+						roleDropdown:SetList(SCM.Constants.Roles)
+						roleDropdown:SetMultiselect(true)
+						roleDropdown:SetCallback("OnValueChanged", function(_, _, key, value)
+							SCM:SetAnchorLayoutCallbackRoleEnabled(addOnName, key, value)
+							SCM:ApplyAllCDManagerConfigs()
+							RefreshList()
+						end)
+						for key, value in pairs(roles) do
+							roleDropdown:SetItemValue(key, value)
+						end
+						row:AddChild(roleDropdown)
+					end
+
+					local status = AceGUI:Create("Label")
+					status:SetRelativeWidth(roles and 0.1 or 0.4)
+					status:SetText(callbackEntry.lastError and "|cFFFF5555Error|r" or "|cFF55FF55Ready|r")
+					row:AddChild(status)
+				end
+			end
+		end
+
+		listContainer:DoLayout()
+		anchorLayoutSettings:DoLayout()
+		parent:DoLayout()
+	end
+
+	local refresh = AceGUI:Create("Button")
+	refresh:SetRelativeWidth(0.25)
+	refresh:SetText("Refresh")
+	refresh:SetCallback("OnClick", RefreshList)
+	anchorLayoutSettings:AddChild(refresh)
+	anchorLayoutSettings:AddChild(listContainer)
+
+	RefreshList()
+end
 
 local function Temporary(self, frame, group)
 	local options = SCM.db.profile.options
@@ -17,7 +98,7 @@ local function Temporary(self, frame, group)
 	label:SetHeight(24)
 	label:SetJustifyH("CENTER")
 	label:SetJustifyV("MIDDLE")
-	label:SetText("|TInterface\\common\\help-i:40:40:0:0|tSome options will be removed once a better alternative has been found/made.")
+	label:SetText("|TInterface\\common\\help-i:40:40:0:0|tIntegration options for unit frames and external anchor consumers.")
 	label:SetFontObject("Game12Font")
 	generalFrame:AddChild(label)
 
@@ -126,6 +207,8 @@ local function Temporary(self, frame, group)
 		SCM:ApplyAllCDManagerConfigs()
 	end)
 	uufSettings:AddChild(xOffset)
+
+	AddAnchorLayoutCallbackSettings(generalFrame)
 
 	local resourceBarSettings = AceGUI:Create("InlineGroup")
 	resourceBarSettings:SetLayout("flow")

--- a/api.lua
+++ b/api.lua
@@ -51,6 +51,25 @@ function SCMAPI.RegisterCustomAnchor(frame, options, override)
 	end
 end
 
+-- callback(group, anchorFrame, effectiveWidth, effectiveHeight, rowConfig, options, enabled)
+-- callbackOptions: { displayName = string, defaultEnabled = boolean, group = number, groups = table, roles = table }
+function SCMAPI.RegisterAnchorLayoutCallback(addOnName, callback, callbackOptions, override)
+	if type(callbackOptions) == "boolean" then
+		override = callbackOptions
+		callbackOptions = nil
+	end
+
+	return SCM:RegisterAnchorLayoutCallback(addOnName, callback, callbackOptions, override)
+end
+
+function SCMAPI.UnregisterAnchorLayoutCallback(addOnName)
+	return SCM:UnregisterAnchorLayoutCallback(addOnName)
+end
+
+function SCMAPI.IsAnchorLayoutCallbackEnabled(addOnName)
+	return SCM:IsAnchorLayoutCallbackEnabled(addOnName)
+end
+
 function SCMAPI.RegisterCustomEntry(customEntry)
 	tinsert(SCM.CustomEntries, customEntry)
 end

--- a/core.lua
+++ b/core.lua
@@ -13,6 +13,9 @@ SCM.MainTabs = {}
 SCM.OptionsCallbacks = {}
 SCM.Skins = {}
 SCM.CustomAnchors = {}
+SCM.AnchorLayoutCallbacks = {}
+SCM.AnchorLayoutCallbackOrder = {}
+SCM.AnchorLayoutState = {}
 SCM.CustomEntries = {}
 SCM.Templates = {}
 


### PR DESCRIPTION
## What does it do?
Adds a public anchor layout callback API so external unitframe addons can attach to Skiron's dynamic anchor layout without Skiron needing addon-specific integrations.

## Why

Skiron's temporary anchor width and height change when the visible icon count or row layout changes. Unitframe addons that want to sit next to those anchors need a reliable way to react to those layout changes.

Today this requires addon-specific code inside Skiron, like the existing UUF and ElvUI paths. This PR exposes the same layout information through a small public callback API, so MSUF and future unitframe addons can integrate cleanly without adding more hardcoded addon branches to Skiron.

## What changed?
- Adds SCMAPI.RegisterAnchorLayoutCallback
- Adds unregister and enabled-state helper APIs
- Notifies registered addons when Skiron's group anchor layout changes
- Adds saved per-integration enable and role settings
- Adds an Integrations options section for public anchor integrations
- Keeps existing UUF and ElvUI behavior intact