### PR TITLE
Make ItemOrSpellExists more strict for Spells

### DIFF
--- a/Modules/customicons.lua
+++ b/Modules/customicons.lua
@@ -580,7 +580,11 @@ local function DoesItemOrSpellExists(config)
 		return true
 	end
 
-	if iconType == "spell" or iconType == "timer" or iconType == "bloodlust" then
+	if iconType == "spell" then
+		return config.spellID and C_SpellBook.IsSpellInSpellBook(config.spellID)
+	end
+
+	if iconType == "timer" or iconType == "bloodlust" then
 		return config.spellID and C_Spell.DoesSpellExist(config.spellID)
 	end
 


### PR DESCRIPTION
Makes it so the check for specifically the "spell" type is more strict. Needs to be Known or potential Spell Override instead of just the spell existing.

Any spell the player can ever use should fulfill this criteria. Doesnt affect Custom->Timers.

Makes it so Custom Spells that requires talents isnt visible if not specced into.