### PR TITLE
Add hide item count in combat option.

### DIFF
--- a/Modules/customicons.lua
+++ b/Modules/customicons.lua
@@ -9,6 +9,8 @@ local GetIconType = Utils.GetIconType
 local ResetChildSCMState = Utils.ResetChildSCMState
 local ToGlobalGroup = Utils.ToGlobalGroup
 
+local InCombatLockdown = InCombatLockdown
+
 local CustomItemFrames = {}
 local CustomSpellFrames = {}
 local BloodlustTimerEntries = {}
@@ -260,12 +262,15 @@ local function SetCustomIconCountText(frame, iconType, config)
 
 	local itemID = frame.SCMItemID
 
+	-- Returns true if in combat and hideStackInCombat is toggled on, otherwise false
+	local hideCount = config.hideStackInCombat == true and InCombatLockdown()
+
 	local count = C_Item.GetItemCount(itemID, false, true)
-	if not config.hideStackText then
+	if config.hideStackText or hideCount then
+		frame.ChargeCount.Current:SetText("")
+	else
 		frame.ChargeCount.Current:SetText(count)
 		frame.ChargeCount.Current:Show()
-	else
-		frame.ChargeCount.Current:SetText("")
 	end
 
 	if count <= 0 then
@@ -1173,14 +1178,17 @@ function CustomIcons.UpdateSpellRange(spellID, isInRange, checksRange)
 	end
 end
 
-local function UpdateCountTextForConfigTable(customConfig)
+-- Add combatOnly check to: CustomIcons.UpdateItemCountText(combatOnly) and UpdateCountTextForConfigTable(customConfig, combatOnly)
+-- so that we only process icons with hideStackInCombat enabled when player regen enabled/disabled event fires, would otherwise do a full update on all icons.
+
+local function UpdateCountTextForConfigTable(customConfig, combatOnly)
 	local visibilityChanged = false
 
 	for id, config in pairs(customConfig) do
 		local frame = CustomItemFrames[id]
 		if frame and not frame.SCMReleased then
 			local iconType = frame.SCMIconType
-			if iconType ~= "empty" then
+			if iconType ~= "empty" and (not combatOnly or config.hideStackInCombat) then
 				local previousItemID = frame.SCMItemID
 				local itemID = SetCustomItemID(frame, config)
 				if itemID ~= previousItemID then
@@ -1202,15 +1210,15 @@ local function UpdateCountTextForConfigTable(customConfig)
 	return visibilityChanged
 end
 
-function CustomIcons.UpdateItemCountText()
+function CustomIcons.UpdateItemCountText(combatOnly)
 	local visibilityChanged = false
 	local customConfig = SCM.customConfig
-	if customConfig and UpdateCountTextForConfigTable(customConfig.itemConfig) then
+	if customConfig and UpdateCountTextForConfigTable(customConfig.itemConfig, combatOnly) then
 		visibilityChanged = true
 	end
 
 	local globalCustomConfig = SCM.globalCustomConfig
-	if globalCustomConfig and UpdateCountTextForConfigTable(globalCustomConfig.itemConfig) then
+	if globalCustomConfig and UpdateCountTextForConfigTable(globalCustomConfig.itemConfig, combatOnly) then
 		visibilityChanged = true
 	end
 

--- a/Options/cdm/spellConfig/tabs/display.lua
+++ b/Options/cdm/spellConfig/tabs/display.lua
@@ -3,7 +3,8 @@ local Options = SCM.Options
 local CDMOptions = Options.CDM
 local AceGUI = LibStub("AceGUI-3.0")
 
-local function AddIconColorOptions(iconSettingsTabs, iconSettings, scrollFrame, buttonFrame, buttonData, buttonConfig, anchorIndex, mode, isGlobal, isBuffBar)
+local function AddIconColorOptions(iconSettingsTabs, iconSettings, scrollFrame, buttonFrame, buttonData, buttonConfig,
+								   anchorIndex, mode, isGlobal, isBuffBar)
 	local options = SCM.db.profile.options
 
 	if buttonData.isCustom or buttonFrame.data.isBuffIcon then
@@ -52,7 +53,8 @@ local function AddIconColorOptions(iconSettingsTabs, iconSettings, scrollFrame, 
 	end
 end
 
-local function AddIconTextOptions(iconSettingsTabs, iconSettings, scrollFrame, buttonFrame, buttonData, buttonConfig, anchorIndex, mode, isGlobal, isBuffBar)
+local function AddIconTextOptions(iconSettingsTabs, iconSettings, scrollFrame, buttonFrame, buttonData, buttonConfig,
+								  anchorIndex, mode, isGlobal, isBuffBar)
 	if buttonData.isCustom and (buttonData.iconType == "item" or buttonData.iconType == "spell") then
 		local textOptions = AceGUI:Create("InlineGroup")
 		textOptions:SetLayout("flow")
@@ -71,15 +73,30 @@ local function AddIconTextOptions(iconSettingsTabs, iconSettings, scrollFrame, b
 			end)
 			textOptions:AddChild(showCraftQuality)
 
+			local hideStackInCombat -- Define local earlier so that hideStackText toggle can disable it later
+
 			local hideStackText = AceGUI:Create("CheckBox")
 			hideStackText:SetLabel("Hide Count")
 			hideStackText:SetRelativeWidth(0.5)
 			hideStackText:SetValue(buttonConfig.hideStackText)
 			hideStackText:SetCallback("OnValueChanged", function(self, event, value)
 				buttonConfig.hideStackText = value or nil
+				hideStackInCombat:SetDisabled(value)
 				CDMOptions.ApplyIconConfigUpdate(buttonFrame, buttonData, anchorIndex, mode, isGlobal, isBuffBar)
 			end)
 			textOptions:AddChild(hideStackText)
+
+			-- hideStackInCombat toggle
+			hideStackInCombat = AceGUI:Create("CheckBox")
+			hideStackInCombat:SetLabel("Hide Count In Combat")
+			hideStackInCombat:SetRelativeWidth(0.5)
+			hideStackInCombat:SetValue(buttonConfig.hideStackInCombat)
+			hideStackInCombat:SetDisabled(buttonConfig.hideStackText)
+			hideStackInCombat:SetCallback("OnValueChanged", function(self, event, value)
+				buttonConfig.hideStackInCombat = value or nil
+				CDMOptions.ApplyIconConfigUpdate(buttonFrame, buttonData, anchorIndex, mode, isGlobal, isBuffBar)
+			end)
+			textOptions:AddChild(hideStackInCombat)
 		elseif buttonData.iconType == "spell" then
 			local forceShowCharges = AceGUI:Create("CheckBox")
 			forceShowCharges:SetLabel("Force Show Charges")
@@ -94,7 +111,10 @@ local function AddIconTextOptions(iconSettingsTabs, iconSettings, scrollFrame, b
 	end
 end
 
-function CDMOptions.CreateDisplayTabSettings(iconSettingsTabs, iconSettings, scrollFrame, buttonFrame, buttonData, iconConfig, anchorIndex, mode, isGlobal, isBuffBar)
-	AddIconColorOptions(iconSettingsTabs, iconSettings, scrollFrame, buttonFrame, buttonData, iconConfig, anchorIndex, mode, isGlobal, isBuffBar)
-	AddIconTextOptions(iconSettingsTabs, iconSettings, scrollFrame, buttonFrame, buttonData, iconConfig, anchorIndex, mode, isGlobal, isBuffBar)
+function CDMOptions.CreateDisplayTabSettings(iconSettingsTabs, iconSettings, scrollFrame, buttonFrame, buttonData,
+											 iconConfig, anchorIndex, mode, isGlobal, isBuffBar)
+	AddIconColorOptions(iconSettingsTabs, iconSettings, scrollFrame, buttonFrame, buttonData, iconConfig, anchorIndex,
+		mode, isGlobal, isBuffBar)
+	AddIconTextOptions(iconSettingsTabs, iconSettings, scrollFrame, buttonFrame, buttonData, iconConfig, anchorIndex,
+		mode, isGlobal, isBuffBar)
 end

--- a/events.lua
+++ b/events.lua
@@ -14,6 +14,7 @@ function SCM:PLAYER_ENTERING_WORLD(isInitialLogin, isReload)
 		SCM:CreateCastBar()
 
 		eventFrame:RegisterEvent("PLAYER_EQUIPMENT_CHANGED")
+		eventFrame:RegisterEvent("PLAYER_REGEN_ENABLED")
 		eventFrame:RegisterEvent("PLAYER_REGEN_DISABLED")
 		eventFrame:RegisterEvent("SPELL_UPDATE_COOLDOWN")
 		eventFrame:RegisterEvent("SPELL_UPDATE_CHARGES")
@@ -158,7 +159,13 @@ function SCM:PLAYER_EQUIPED_SPELLS_CHANGED()
 	eventFrame:UnregisterEvent("PLAYER_EQUIPED_SPELLS_CHANGED")
 end
 
-function SCM:PLAYER_REGEN_DISABLED() end
+function SCM:PLAYER_REGEN_ENABLED()
+	SCM.CustomIcons.UpdateItemCountText(true) -- Combat started, check icons with config.hideStackInCombat
+end
+
+function SCM:PLAYER_REGEN_DISABLED()
+	SCM.CustomIcons.UpdateItemCountText(true) -- Combat ended, check icons with config.hideStackInCombat
+end
 
 function SCM:EDIT_MODE_LAYOUTS_UPDATED()
 	SCM:UpdateDB()


### PR DESCRIPTION
Simple feature to hide count on items (Hp pot, dps pot etc) while in combat.

- GUI Toggle with respect for the fully hide count feature, toggle for combat hide is disabled if count is fully hidden.
- combatOnly added to UpdateItemCountText function so that when PLAYER_REGEN_ENABLED/DISABLED event fires, we only update icons that use the hide count in combat feature, BAG_UPDATE_DELAYED still does a full update.